### PR TITLE
Fix duplicate removal bug

### DIFF
--- a/prime_scraper.py
+++ b/prime_scraper.py
@@ -59,7 +59,7 @@ def safe_history(url):
 
 frames = []
 for url_name in prime_sets:
-    frames.append(get_history(url_name))
+    frames.append(safe_history(url_name))
     time.sleep(1)  # to avoid hitting API rate limits
 
 raw = pd.concat(frames, ignore_index=True)
@@ -80,11 +80,11 @@ clean = (
 )
 
 # remove duplicates in case of API errors
-raw.sort_values(["item", "datetime"], inplace=True)
-clean = raw.drop_duplicates(subset=["item", "datetime"]) 
+clean.sort_values(["item", "datetime"], inplace=True)
+clean = clean.drop_duplicates(subset=["item", "datetime"])
 
 # remove rows with no volume data
-raw = raw.dropna(subset=["volume"])
+clean = clean.dropna(subset=["volume"])
 
 
 # split datetime for easier grouping


### PR DESCRIPTION
## Summary
- call `safe_history` instead of `get_history` to handle network issues gracefully
- apply duplicate and null row filters to the cleaned dataframe

## Testing
- `pip install -r requirements.txt`
- `python prime_scraper.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68844fbfe3208323ad8fa6ea0540e5d4