### PR TITLE
Fix cleaning sequence to operate on clean DataFrame

### DIFF
--- a/prime_scraper.py
+++ b/prime_scraper.py
@@ -80,11 +80,11 @@ clean = (
 )
 
 # remove duplicates in case of API errors
-raw.sort_values(["item", "datetime"], inplace=True)
-clean = raw.drop_duplicates(subset=["item", "datetime"]) 
+clean.sort_values(["item", "datetime"], inplace=True)
+clean = clean.drop_duplicates(subset=["item", "datetime"])
 
 # remove rows with no volume data
-raw = raw.dropna(subset=["volume"])
+clean = clean.dropna(subset=["volume"])
 
 
 # split datetime for easier grouping


### PR DESCRIPTION
## Summary
- update prime_scraper to sort, deduplicate and dropna on the `clean` DataFrame
- keep replacement of zeros and type casting steps intact

## Testing
- `python -m py_compile prime_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68859310e47483239a292532f670dd6a