### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo:
 
 ---
 ## Live Preview
-* My attempt at deploying a website using Jekyll. It's very basic and unoptimized as I'm still a beginner but its functional!
+* My attempt at deploying a website using Jekyll. It’s very basic and unoptimized as I’m still a beginner but it’s functional!
 * [Link Here](https://sugarandqueries.github.io/Prime-Set-Price-Checker/)
 
 ## Quick start


### PR DESCRIPTION
## Summary
- update README to fix punctuation for "it's" in live preview section

## Testing
- `python -m py_compile prime_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_6885930d02e8832385a90909c74e52e8